### PR TITLE
fix(config): write config to config.json file instead of directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl Configure {
     }
 
     pub fn store(&self) {
-        let config_path = jvr_home_dir();
+        let config_path = jvr_config_json_path();
         let config_content =
             serde_json::to_string_pretty(self).expect("Failed to serialize config");
         fs::write(config_path, config_content).expect("Failed to write config file");


### PR DESCRIPTION
Original code in the store method attempted to write the configuration data directly to the configuration directory (e.g., ~/.jvr) instead of the intended configuration file (e.g., ~/.jvr/config.json).
Since operating systems do not allow writing file content directly to a directory, this resulted in the following error:

```text
Failed to write config file: Os { code: 5, kind: PermissionDenied, message: "Access is denied." }
```

Replace jvr_home_dir() with jvr_config_json_path() in the store method to ensure the configuration is written to the config.json file, not the directory.

**Reproduction & Verification**
1. Reproduction: With the original code, running commands like add or use would result in a "Permission Denied" error.
2. Verification: After the fix, these commands execute successfully, and the ~/.jvr/config.json file is correctly updated.